### PR TITLE
change -y flage location in the `install | enable pxc 80` repo task

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -52,7 +52,7 @@
         name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
 
     - name: install | enable pxc 80 repo
-      shell: percona-release setup pxc80 -y
+      shell: percona-release setup -y pxc80
       when: not arbiter_installed
 
     - name: install | percona xtradb cluster


### PR DESCRIPTION
Leaving the `-y` flag at the end of the percona-release setup command like that: 'percona-release setup -y pxc80" may result with error `Specified repository is not supported for current operating system! ` as the command will try to find repository by the name -y.