### PR TITLE
Feat/pxc84 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is for either for a single node, or when using 2 nodes or more. The functio
 
 This role is tested w Ansible v2.9 and higher.
 
- * Percona XtraDB Cluster 8
+ * Percona XtraDB Cluster 8.0 and 8.4 LTS
  * Secured connection by encrypting mysql traffic
  * Bootstrapping a cluster, includes end2end tests
  * Scaling: add or remove hosts from the cluster **with ease**!
@@ -28,6 +28,11 @@ This role is tested w Ansible v2.9 and higher.
  * When clustering, the nodes are able to connect to each other via ports 4444, 4567, 4568, see [info](https://www.percona.com/doc/percona-xtradb-cluster/LATEST/faq.html#what-tcp-ports-are-used-by-percona-xtradb-cluster)
  * Plenty of disk space, keep the backup in mind as well. The use of an SSD is preferred for performance
  * Internet connection to download installation files
+ * Ansible collection `community.mysql >= 3.8.0`
+
+```bash
+ansible-galaxy collection install community.mysql
+```
 
 Copy the variables from `default/main.yml` and adjust them for each node in it's variable folder.
 
@@ -38,7 +43,8 @@ The arbiter requires less configuration, see below.
 Please first check `defaults/main.yml` for all the variables and to get a good overview.
 
 First, the mysql user and group are set on the system. Then, the dependencies are installed.
-Since Percona is installed via the official Percona XtraDB repository, the GPG Keys are added.
+Since Percona is installed via the official Percona XtraDB repository, the GPG Keys are added and
+the repository is configured directly via the Ansible `yum_repository` module.
 
 The python package [pymysql](https://pypi.org/project/PyMySQL) is required for certain Ansible mysql modules, so this is installed by default. It is installed via pip3, which is installed by default w setuptools.
 
@@ -52,6 +58,15 @@ The variables for passwords can be set in the `group_vars/all.yml`. Ensure to ch
 percona_root_password: 'change_me'
 percona_system_password: 'change_me'
 percona_sst_password: 'change_me'
+```
+
+### PXC version
+
+By default, PXC 8.4 LTS is installed. To install PXC 8.0 instead, override the following variables:
+
+```yaml
+percona_pxc_version: '8.0'
+percona_pxc_repo_suffix: '80'
 ```
 
 Before starting/restart the mysql service, a config test is executed. If the config check fails, then the role will also fail. This is done in order to maintain a working mysql service. So please test properly on lower environments when adding/removing configurations to mysql.
@@ -145,8 +160,9 @@ percona_cluster_scale_restart_all: false
 
 ## Login
 
-By default, the user debian-sys-maint is created, with root privileges.
-The credentials are set in `/etc/mysql/root.cnf` and is symlinked to `/root/.my.cnf`. One with sudo access can therefore simply execute `mysql` and execute mysql commands.
+On RHEL-based systems, the `root` user credentials are stored in `/etc/mysql/root.cnf`, symlinked to `/root/.my.cnf`. One with sudo access can therefore simply execute `mysql` and execute mysql commands.
+
+On Debian-based systems, the `debian-sys-maint` user is created with root privileges, and its credentials are stored in the same files.
 
 ```bash
 [vagrant@test-multi-02 ~]$ sudo mysql

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+percona_pxc_version: '8.4'
+
 percona_package_deps:
   - gnupg2
   - socat
@@ -108,8 +110,6 @@ mysqld:
     log_buffer_size: 16M
     flush_log_at_trx_commit: 2
     autoinc_lock_mode: 2
-    file_format: Barracuda
-    large_prefix: 1
     adaptive_hash_index: 1
     adaptive_hash_index_parts: 8
     lru_scan_depth: 1024

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 percona_pxc_version: '8.4'
+percona_pxc_repo_suffix: '84-lts'
 
 percona_package_deps:
   - gnupg2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,7 +103,7 @@ mysqld:
     charset: utf8mb4
     collate: utf8mb4_unicode_ci
   innodb:
-    dedicated_server: enabled
+    dedicated_server: 'ON'
     flush_method: O_DIRECT
     file_per_table: 1
     temp_data_file_path: ibtmp1:12M:autoextend:max:1G

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -80,10 +80,10 @@
         - name: cluster | create SST user on bootstrapper
           mysql_user:
             login_unix_socket: /var/run/mysqld/mysqld.sock
-            login_host: ''
-            user: sst
+            name: sst
             password: "{{ percona_sst_password }}"
-            priv: "*.*:grant,reload,lock tables,process,replication client"
+            priv: "*.*:GRANT,RELOAD,LOCK TABLES,PROCESS,REPLICATION CLIENT"
+            state: present
           no_log: "{{ percona_no_log }}"
           when: bootstrapper
 

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -83,6 +83,7 @@
             name: sst
             password: "{{ percona_sst_password }}"
             priv: "*.*:GRANT,RELOAD,LOCK TABLES,PROCESS,REPLICATION CLIENT"
+            plugin: caching_sha2_password
             state: present
           no_log: "{{ percona_no_log }}"
           when: bootstrapper

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -78,13 +78,13 @@
           when: bootstrapper
 
         - name: cluster | create SST user on bootstrapper
-          mysql_user:
-            login_unix_socket: /var/run/mysqld/mysqld.sock
-            name: sst
-            password: "{{ percona_sst_password }}"
-            priv: "*.*:GRANT,RELOAD,LOCK TABLES,PROCESS,REPLICATION CLIENT"
-            plugin: caching_sha2_password
-            state: present
+          shell: >
+            mysql -e "CREATE USER IF NOT EXISTS 'sst'@'%'
+            IDENTIFIED WITH caching_sha2_password BY '{{ percona_sst_password }}';
+            GRANT RELOAD, LOCK TABLES, REPLICATION CLIENT, PROCESS ON *.*
+            TO 'sst'@'%';
+            ALTER USER 'sst'@'%'
+            IDENTIFIED WITH caching_sha2_password BY '{{ percona_sst_password }}';"
           no_log: "{{ percona_no_log }}"
           when: bootstrapper
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -51,6 +51,11 @@
       yum:
         name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
 
+    - name: install | update percona-release to latest
+      dnf:
+        name: percona-release
+        state: latest
+
     - name: install | enable pxc repo
       shell: "percona-release setup -y pxc{{ percona_pxc_version | replace('.', '') }}"
       when: not arbiter_installed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,12 +47,14 @@
       rpm_key:
         key: https://repo.percona.com/yum/PERCONA-PACKAGING-KEY
 
-    - name: install | set repo
-      yum:
-        name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
-
-    - name: install | enable pxc repo
-      shell: "/usr/bin/percona-release setup -y pxc{{ percona_pxc_version | replace('.', '') }}"
+    - name: install | set percona pxc repo
+      yum_repository:
+        name: "percona-pxc-{{ percona_pxc_version | replace('.', '') }}"
+        description: "Percona XtraDB Cluster {{ percona_pxc_version }} YUM repository"
+        baseurl: "http://repo.percona.com/pxc-{{ percona_pxc_repo_suffix }}/yum/release/$releasever/RPMS/x86_64"
+        enabled: true
+        gpgcheck: true
+        gpgkey: file:///etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY
       when: not arbiter_installed
 
     - name: install | percona xtradb cluster

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,6 +47,10 @@
       rpm_key:
         key: https://repo.percona.com/yum/PERCONA-PACKAGING-KEY
 
+    - name: install | set repo
+      yum:
+        name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+
     - name: install | set percona pxc repo
       yum_repository:
         name: "percona-pxc-{{ percona_pxc_version | replace('.', '') }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -51,8 +51,8 @@
       yum:
         name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
 
-    - name: install | enable pxc 80 repo
-      shell: percona-release setup -y pxc80
+    - name: install | enable pxc repo
+      shell: "percona-release setup -y pxc{{ percona_pxc_version | replace('.', '') }}"
       when: not arbiter_installed
 
     - name: install | percona xtradb cluster

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -51,13 +51,8 @@
       yum:
         name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
 
-    - name: install | update percona-release to latest
-      dnf:
-        name: percona-release
-        state: latest
-
     - name: install | enable pxc repo
-      shell: "percona-release setup -y pxc{{ percona_pxc_version | replace('.', '') }}"
+      shell: "/usr/bin/percona-release setup -y pxc{{ percona_pxc_version | replace('.', '') }}"
       when: not arbiter_installed
 
     - name: install | percona xtradb cluster

--- a/tasks/root.yml
+++ b/tasks/root.yml
@@ -61,6 +61,7 @@
 
     - name: root | delete anonymous connections
       mysql_user:
+        login_unix_socket: "{{ mysqld.socket }}"
         name: ""
         host_all: true
         state: absent

--- a/tasks/root.yml
+++ b/tasks/root.yml
@@ -43,6 +43,7 @@
         login_user: root
         login_password: "{{ percona_root_password }}"
       no_log: "{{ percona_no_log }}"
+      when: ansible_os_family == 'Debian'
 
     - name: root | copy root.cnf
       template:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,7 +1,6 @@
 ---
 - name: users | ensure users are set
   mysql_user:
-    login_host: ''
     login_unix_socket: "{{ mysqld.socket }}"
     name: "{{ item.name }}"
     password: "{{ item.password }}"
@@ -10,6 +9,7 @@
     host: "{{ item.host }}"
     state: "{{ item.state }}"
     update_password: always
+    plugin: caching_sha2_password
   loop: "{{ percona_users }}"
   changed_when: false
   when: (bootstrapper is defined and bootstrapper) or host_count == '1'

--- a/templates/mysqld.cnf.j2
+++ b/templates/mysqld.cnf.j2
@@ -73,7 +73,6 @@ lower_case_table_names    = {{ mysqld.lower_case_table_names }}
 init_connect                    = 'SET NAMES {{ mysqld.default.charset }} COLLATE {{ mysqld.default.collate }}'
 character-set-server            = {{ mysqld.default.charset }}
 collation-server                = {{ mysqld.default.collate }}
-skip-character-set-client-handshake
 
 # InnoDB settings
 innodb_dedicated_server         = {{ mysqld.innodb.dedicated_server }}

--- a/templates/root.cnf.j2
+++ b/templates/root.cnf.j2
@@ -5,10 +5,20 @@
 
 [client]
 socket   = {{ mysqld.socket }}
+{% if ansible_os_family == 'Debian' %}
 user     = debian-sys-maint
 password = {{ percona_system_password }}
+{% else %}
+user     = root
+password = {{ percona_root_password }}
+{% endif %}
 
 [mysql_upgrade]
 socket   = {{ mysqld.socket }}
+{% if ansible_os_family == 'Debian' %}
 user     = debian-sys-maint
 password = {{ percona_system_password }}
+{% else %}
+user     = root
+password = {{ percona_root_password }}
+{% endif %}


### PR DESCRIPTION
## Summary

- Add `percona_pxc_version` (default `8.4`) and `percona_pxc_repo_suffix` (default `84-lts`) variables to make the PXC version configurable
- Replace `percona-release setup pxcXX` shell command with Ansible `yum_repository` module — the `percona-release` CLI binary is no longer provided by the bootstrap RPM in recent Percona packages
- Remove `innodb.file_format` and `innodb.large_prefix` defaults (removed since MySQL 8.0)
- Fix MySQL 8.4 config: remove `skip-character-set-client-handshake` (removed in 8.4), fix `innodb_dedicated_server` value from `enabled` to `ON`
- Fix RHEL compatibility: skip `debian-sys-maint` user creation on non-Debian systems, use `root` in `.my.cnf` on non-Debian systems
- Fix SST user creation for MySQL 8.4: `mysql_native_password` removed in 8.4, use `caching_sha2_password` instead
- Fix `mysql_user` module: replace deprecated `user:` with `name:`, remove conflicting `login_host: "`

## Test plan

- [x] Fresh install PXC 8.4 cluster (3 nodes) on Rocky Linux 9
- [x] `wsrep_cluster_size = 3` on 3 nodes
- [x] `wsrep_local_state_comment = Synced` on 3 nodes
- [x] verified cross-nodes replication
- [x] SST user created with `caching_sha2_password` 